### PR TITLE
Add driver-provided static dirs

### DIFF
--- a/AFL/automation/APIServer/APIServer.py
+++ b/AFL/automation/APIServer/APIServer.py
@@ -270,7 +270,7 @@ class APIServer:
             if directory.exists():
                 route = f'/static/{subpath}/<path:filename>'
                 endpoint = f'static_{subpath}'
-                handler = functools.partial(send_from_directory, directory)
+                handler = lambda filename, directory=directory: send_from_directory(directory, filename)
                 self.app.add_url_rule(route, endpoint, handler)
 
     def add_unqueued_routes(self):

--- a/AFL/automation/APIServer/APIServer.py
+++ b/AFL/automation/APIServer/APIServer.py
@@ -264,7 +264,21 @@ class APIServer:
         return jsonify(self.driver.queued.function_info),200
 
     def _add_driver_static_routes(self):
-        '''Serve any extra static directories defined by the driver.'''
+        '''Serve any extra static directories defined by the driver.
+        
+        This method creates Flask routes for each directory specified in the driver's
+        static_dirs dictionary. Files are served under /static/{subpath}/ URLs and
+        are accessible via HTTP GET requests.
+        
+        The method only creates routes for directories that actually exist on the
+        filesystem. Non-existent directories are silently skipped.
+        
+        Example:
+            If driver.static_dirs = {'docs': '/path/to/docs', 'assets': '/path/to/assets'}
+            then files will be served at:
+            - /static/docs/filename -> serves files from /path/to/docs/
+            - /static/assets/filename -> serves files from /path/to/assets/
+        '''
         for subpath, directory in getattr(self.driver, 'static_dirs', {}).items():
             directory = pathlib.Path(directory)
             if directory.exists():

--- a/AFL/automation/APIServer/Driver.py
+++ b/AFL/automation/APIServer/Driver.py
@@ -43,6 +43,8 @@ class Driver:
     queued = makeRegistrar()
     quickbar = makeRegistrar()
     # Mapping of url subpaths to filesystem directories containing static assets
+    # Example: {'docs': '/path/to/docs', 'assets': pathlib.Path(__file__).parent / 'assets'}
+    # Files will be served at /static/{subpath}/{filename}
     static_dirs = {}
 
     def __init__(self, name, defaults=None, overrides=None, useful_links=None):
@@ -85,7 +87,18 @@ class Driver:
 
     @classmethod
     def gather_static_dirs(cls):
-        '''Gather all inherited class-level dictionaries named static_dirs.'''
+        '''Gather all inherited class-level dictionaries named static_dirs.
+        
+        This method walks through the Method Resolution Order (MRO) to collect
+        static_dirs definitions from all parent classes. Child class definitions
+        override parent definitions for the same subpath key.
+        
+        Returns
+        -------
+        dict
+            Dictionary mapping subpaths to pathlib.Path objects for directories
+            containing static files to be served by the API server.
+        '''
 
         dirs = {}
         for parent in cls.__mro__:

--- a/AFL/automation/APIServer/Driver.py
+++ b/AFL/automation/APIServer/Driver.py
@@ -1,8 +1,8 @@
 from AFL.automation.shared.utilities import listify
 from AFL.automation.shared.PersistentConfig import PersistentConfig
 from AFL.automation.shared import serialization
-from math import ceil,sqrt
-import inspect 
+from math import ceil, sqrt
+import inspect
 import pathlib
 import uuid
 
@@ -42,7 +42,10 @@ class Driver:
     unqueued = makeRegistrar()
     queued = makeRegistrar()
     quickbar = makeRegistrar()
-    def __init__(self,name,defaults=None,overrides=None,useful_links=None):
+    # Mapping of url subpaths to filesystem directories containing static assets
+    static_dirs = {}
+
+    def __init__(self, name, defaults=None, overrides=None, useful_links=None):
         self.app = None
         self.data = None
         self.dropbox = None
@@ -67,6 +70,9 @@ class Driver:
             overrides= overrides,
             )
 
+        # collect inherited static directories
+        self.static_dirs = self.gather_static_dirs()
+
     @classmethod
     def gather_defaults(cls):
         '''Gather all inherited static class-level dictionaries called default.'''
@@ -76,6 +82,16 @@ class Driver:
             if hasattr(parent,'defaults'):
                 defaults.update(parent.defaults)
         return defaults
+
+    @classmethod
+    def gather_static_dirs(cls):
+        '''Gather all inherited class-level dictionaries named static_dirs.'''
+
+        dirs = {}
+        for parent in cls.__mro__:
+            if hasattr(parent, 'static_dirs'):
+                dirs.update({k: pathlib.Path(v) for k, v in getattr(parent, 'static_dirs').items()})
+        return dirs
     
     def set_config(self,**kwargs):
         self.config.update(kwargs)

--- a/docs/source/explanation/architecture.rst
+++ b/docs/source/explanation/architecture.rst
@@ -46,6 +46,7 @@ The driver system is the core of AFL-automation. Drivers:
 - Define configuration parameters with defaults
 - Provide methods for interacting with hardware
 - Support lazy loading of hardware-specific dependencies
+- Can serve static files for custom web interfaces via `static_dirs`
 
 API Server
 ---------
@@ -56,6 +57,7 @@ The API server:
 - Provides authentication and authorization
 - Manages a task queue for asynchronous operations
 - Offers a web UI for monitoring and control
+- Serves static files defined by drivers for custom web interfaces
 
 Dependency Management
 -------------------

--- a/docs/source/explanation/user-interfaces.rst
+++ b/docs/source/explanation/user-interfaces.rst
@@ -74,3 +74,18 @@ A bit long-winded? Sure.
 But this syntax tells a client that this function can be called, using a button labeled "Load Sample", and takes a parameter as described, with a default value.
 
 Quickbar functions appear on the html status page of the server, and can be ingested by other user interfaces such as ipywidgets in a notebook.
+
+Serving Additional Static Files
+-------------------------------
+
+If your driver requires custom JavaScript or images, define a ``static_dirs``
+class attribute mapping subpaths to directories::
+
+    class MyDriver(Driver):
+        static_dirs = {
+            'js': pathlib.Path(__file__).parent / 'js',
+            'img': pathlib.Path(__file__).parent / 'images',
+        }
+
+The APIServer will automatically serve files from these directories at
+``/static/js`` and ``/static/img``.

--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -9,5 +9,6 @@ How-to guides are problem-oriented instructions that help users accomplish speci
    
    dependencies
    my-first-server
+   static-directories
    run-tests
    

--- a/docs/source/how-to/static-directories.rst
+++ b/docs/source/how-to/static-directories.rst
@@ -1,0 +1,150 @@
+===========================
+Serving Static Files in Drivers
+===========================
+
+AFL-automation drivers can serve static files (HTML, CSS, JavaScript, images, etc.) through the API server's web interface. This is useful for providing custom web interfaces, documentation, or any files that need to be accessible via HTTP.
+
+How It Works
+-----------
+
+When you define static directories in your driver class, the API server automatically creates HTTP routes to serve files from those directories. Files are served under the `/static/` URL path.
+
+Basic Usage
+----------
+
+To serve static files from your driver, define a class-level `static_dirs` dictionary that maps URL subpaths to filesystem directories:
+
+.. code-block:: python
+
+    from AFL.automation.APIServer.Driver import Driver
+    import pathlib
+
+    class MyDriver(Driver):
+        # Map URL subpaths to filesystem directories
+        static_dirs = {
+            'docs': '/path/to/my/documentation',
+            'assets': '/path/to/web/assets',
+            'data': pathlib.Path(__file__).parent / 'static_data'
+        }
+
+        def __init__(self, name="MyDriver"):
+            super().__init__(name)
+            # static_dirs are automatically collected and configured
+
+With this configuration:
+
+- Files in `/path/to/my/documentation/` are served at `http://server:port/static/docs/filename`
+- Files in `/path/to/web/assets/` are served at `http://server:port/static/assets/filename`  
+- Files in `static_data/` directory are served at `http://server:port/static/data/filename`
+
+Inheritance
+----------
+
+Static directories are inherited from parent classes and combined using the Method Resolution Order (MRO). This allows for modular composition of static assets:
+
+.. code-block:: python
+
+    class BaseDriver(Driver):
+        static_dirs = {
+            'common': '/shared/assets',
+            'docs': '/base/documentation'
+        }
+
+    class SpecializedDriver(BaseDriver):
+        static_dirs = {
+            'custom': '/specialized/assets',
+            'docs': '/specialized/documentation'  # Overrides base docs
+        }
+
+    # SpecializedDriver will serve:
+    # /static/common/ -> /shared/assets
+    # /static/custom/ -> /specialized/assets  
+    # /static/docs/ -> /specialized/documentation (overridden)
+
+Example: Custom Web Interface
+----------------------------
+
+Here's a complete example of a driver that serves a custom web interface:
+
+.. code-block:: python
+
+    import pathlib
+    from AFL.automation.APIServer.Driver import Driver
+
+    class DataVisualizationDriver(Driver):
+        # Serve web interface files
+        static_dirs = {
+            'viewer': pathlib.Path(__file__).parent / 'web_interface',
+            'plots': pathlib.Path(__file__).parent / 'generated_plots'
+        }
+
+        def __init__(self, name="DataViz"):
+            super().__init__(name)
+
+        @queued(render_hint='html')
+        def view_dashboard(self):
+            """Return HTML that loads the custom web interface"""
+            return '''
+            <iframe src="/static/viewer/dashboard.html" 
+                    width="100%" height="600px">
+            </iframe>
+            '''
+
+Directory Structure
+-----------------
+
+For the above example, your directory structure might look like:
+
+::
+
+    my_driver/
+    ├── driver.py                    # Your driver class
+    ├── web_interface/              # static_dirs['viewer']
+    │   ├── dashboard.html
+    │   ├── style.css
+    │   ├── app.js
+    │   └── lib/
+    │       └── charts.js
+    └── generated_plots/            # static_dirs['plots']
+        ├── plot1.png
+        └── plot2.svg
+
+Files would be accessible at:
+
+- `http://server:port/static/viewer/dashboard.html`
+- `http://server:port/static/viewer/style.css`
+- `http://server:port/static/viewer/lib/charts.js`
+- `http://server:port/static/plots/plot1.png`
+
+Security Considerations
+---------------------
+
+- Only files within the specified directories are served
+- Directory traversal attacks (e.g., `../../../etc/passwd`) are prevented by Flask's `send_from_directory` function
+- Consider the sensitivity of files you're serving - they'll be publicly accessible if the server is accessible
+- Use appropriate file permissions on the directories you're serving
+
+Best Practices
+-------------
+
+1. **Use relative paths**: Use `pathlib.Path(__file__).parent` to make paths relative to your driver file
+2. **Organize logically**: Group related files under meaningful subpath names
+3. **Version control**: Include static assets in your driver's version control
+4. **Documentation**: Document what static endpoints your driver provides
+5. **Testing**: Test that your static files are served correctly after server startup
+
+Troubleshooting
+--------------
+
+**Files not being served**
+
+- Verify the directory exists and contains files
+- Check file permissions are readable by the server process
+- Confirm the `static_dirs` dictionary is defined at the class level
+- Check server logs for any error messages
+
+**Wrong files being served**
+
+- Check for inheritance conflicts if using multiple driver classes
+- Verify the correct directory paths in `static_dirs`
+- Remember that child classes override parent class mappings for the same subpath 


### PR DESCRIPTION
## Summary
- allow drivers to list extra static directories that are served by APIServer
- document static directory usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b9d79c34832196fd077fa9f5dd75